### PR TITLE
add parameter -A to set default reject score for (outgoing) mails from SASL authenticated users

### DIFF
--- a/args.h
+++ b/args.h
@@ -18,6 +18,7 @@ typedef enum {
 extern int args_debug;
 extern int args_scan_auth;
 extern int args_report;
+extern float args_scan_auth_score;
 extern const char *args_commsocket;
 extern const char *args_pidfile;
 extern const char *args_spamdsocket;

--- a/lcsam.c
+++ b/lcsam.c
@@ -449,8 +449,8 @@ static sfsistat lcsam_envrcpt(SMFICTX *ctx, char **args) {
 
 			/* scan outgoing e-mail:
 			 * use some "high" settings - blocking should be done later using the appropriate headers */
-			priv->warn = 999;
-			priv->reject = 999;
+			priv->warn = args_scan_auth_score;
+			priv->reject = args_scan_auth_score;
 			priv->subjectprefix[0] = '\0';
 			return(SMFIS_CONTINUE);
 		} else if (ret != 0) {
@@ -503,9 +503,9 @@ static sfsistat lcsam_header(SMFICTX *ctx, char *name, char *value) {
 		if (priv->mbox_path[0] != '\0') {
 			fdprintf(priv, "User: %s\r\n", priv->mbox_path);
 		}
-	
+
 		fdprintf(priv, "\r\n");
-	
+
 		/* send fake Received: header */
 		fdprintf(priv, "Received: from %s (%s [%s])",
 		    priv->helo, priv->hostname, priv->hostaddr);


### PR DESCRIPTION
Kein großer Aufwand, daher einfach mal umgesetzt.